### PR TITLE
Moved the caching outside of the interceptor

### DIFF
--- a/example/frontend_react/concepts/eventEmitter.ts
+++ b/example/frontend_react/concepts/eventEmitter.ts
@@ -16,15 +16,6 @@ class EventEmitter {
   get(key: string) {
     return this.#store[key];
   }
-
-  put(key: string, value: any) {
-    this.#store[key] = value;
-    return true;
-  }
-
-  getAll() {
-    return this.#store;
-  }
 }
 
 const eventEmitter = new EventEmitter();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "grpcexpress",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Issue

The grpc call gets blocked by cors in Chrome. This was caused by the storeKey metadata we injected.

## Changes

- To avoid injecting invalid metadata, we moved the caching mechanism outside of the interceptor. Therefore, we no longer need an interceptor. 
- Removed unused methods from the eventEmitter class.