### PR TITLE
Refactored cache expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @grpcexpress/grpcexpress
 
+## 0.2.1
+
+### Patch Changes
+
+- Refactored the cache expiration from setTimeout to checking an expiration date
+
 ## 0.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpcexpress/grpcexpress",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "private": false,
   "main": "./dist/index.js",

--- a/src/CacheStore.test.ts
+++ b/src/CacheStore.test.ts
@@ -5,7 +5,7 @@ import { CacheStore } from './CacheStore';
 describe('CacheStore', () => {
   let cacheStore: CacheStore;
   beforeAll(() => {
-    cacheStore = new CacheStore();
+    cacheStore = new CacheStore(600000);
   });
 
   it('should create a cache store', () => {
@@ -16,7 +16,7 @@ describe('CacheStore', () => {
     const buffer = new Uint8Array([1]);
     cacheStore.subscribe('testKey', buffer);
     const value = cacheStore.get('testKey');
-    expect(value).toEqual({ buffer: buffer });
+    expect(value).toEqual(buffer);
   });
 
   it('should be able to unsubscribe', () => {

--- a/src/PendingStore.test.ts
+++ b/src/PendingStore.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import pendingStore from './PendingStore';
+import CacheStore from './CacheStore';
+import PendingStore from './PendingStore';
 
 describe('PendingStore', () => {
+  const cacheStore = new CacheStore(600000);
+  const pendingStore = new PendingStore(cacheStore);
   it('should be able to set a function call as pending', () => {
     pendingStore.setPending('test');
     expect(pendingStore.has('test')).toEqual(true);

--- a/src/PendingStore.ts
+++ b/src/PendingStore.ts
@@ -1,4 +1,4 @@
-import cacheStore from './CacheStore';
+import CacheStore from './CacheStore';
 
 type item = {
   isPending: boolean;
@@ -7,9 +7,11 @@ type item = {
 
 class PendingStore {
   #store: { [key: string]: item };
+  #cacheStore: CacheStore;
 
-  constructor() {
+  constructor(cacheStore: CacheStore) {
     this.#store = {};
+    this.#cacheStore = cacheStore;
   }
 
   setPending(key: string) {
@@ -21,7 +23,7 @@ class PendingStore {
 
   setDone(key: string) {
     for (const resolve of this.#store[key].callbacks) {
-      resolve(cacheStore.get(key));
+      resolve(this.#cacheStore.get(key));
     }
     delete this.#store[key];
   }
@@ -39,6 +41,4 @@ class PendingStore {
   }
 }
 
-const pendingStore = new PendingStore();
-
-export default pendingStore;
+export default PendingStore;


### PR DESCRIPTION
## Request Type
<!-- Select one of the following types that best describes this pull request: -->
- [X] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (Specify): ____________________

## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
Refactored cache expiration from setTimeout to check an expiration date.

## Issue
<!-- Link to the related issue(s) or provide context for this pull request. -->
Previously we used setTimeout to expire a cache. However, we couldn't save the setTimeout function to localStorage when the user exits or refreshes the site.

## Changes Made
<!-- List the specific changes made in this pull request, including any relevant code, files, or configurations. -->
Refactored the logic to check for the expiration date associated with the cache item. The expiration is passed in as an option at the client instantiation and can be overridden on any service method call. The default expiration is 10 minutes.
